### PR TITLE
feat(nim): disable compiler warnings

### DIFF
--- a/languages/nim/run.sh
+++ b/languages/nim/run.sh
@@ -1,2 +1,2 @@
 cat > program.nim
-nim compile --run --colors=off --memTracker=off --verbosity=0 --hints=off --nimcache:/tmp/"$CODEDIR"/cache ./program.nim
+nim compile --run --colors=off --memTracker=off --verbosity=0 --hints=off --warnings=off --nimcache:/tmp/"$CODEDIR"/cache ./program.nim


### PR DESCRIPTION
Running this code produces the below output:
```nim
import sugar

echo "Hello, world"
```
```diff
-/tmp/eval/8290979244272517120/program.nim(2, 8) Warning: imported and not used: 'sugar' [UnusedImport]
Hello, world
```