### PR TITLE
Add setting for custom runtime of containers

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,6 +13,9 @@ port: 8081
 
 # The default language configuration.
 defaultLanguage:
+    # The OCI runtime to use when running the container.
+    runtime: runc
+
     # The maximum memory and swap usage (separately) of a container.
     memory: 256m
 

--- a/src/Myriad/Config.hs
+++ b/src/Myriad/Config.hs
@@ -21,6 +21,7 @@ type LanguageName = T.Text
 
 data Language = Language
     { _name :: LanguageName
+    , _runtime :: T.Text
     , _memory :: T.Text
     , _cpus :: Double
     , _timeout :: Int
@@ -42,7 +43,8 @@ data Config = Config
 makeFieldLabelsWith classUnderscoreNoPrefixFields ''Config
 
 data DefaultLanguage = DefaultLanguage
-    { _memory :: T.Text
+    { _runtime :: T.Text
+    , _memory :: T.Text
     , _cpus :: Double
     , _timeout :: Int
     , _concurrent :: Int
@@ -54,7 +56,8 @@ makeFieldLabelsWith classUnderscoreNoPrefixFields ''DefaultLanguage
 
 instance FromJSON DefaultLanguage where
     parseJSON = withObject "default language" $ \m -> DefaultLanguage
-        <$> m .: "memory"
+        <$> m .: "runtime"
+        <*> m .: "memory"
         <*> m .: "cpus"
         <*> m .: "timeout"
         <*> m .: "concurrent"
@@ -63,6 +66,7 @@ instance FromJSON DefaultLanguage where
 
 data RawLanguage = RawLanguage
     { _name :: LanguageName
+    , _runtime :: Maybe T.Text
     , _memory :: Maybe T.Text
     , _cpus :: Maybe Double
     , _timeout :: Maybe Int
@@ -76,6 +80,7 @@ makeFieldLabelsWith classUnderscoreNoPrefixFields ''RawLanguage
 instance FromJSON RawLanguage where
     parseJSON = withObject "language" $ \m -> RawLanguage
         <$> m .: "name"
+        <*> m .:? "runtime"
         <*> m .:? "memory"
         <*> m .:? "cpus"
         <*> m .:? "timeout"
@@ -127,6 +132,7 @@ fromRawLanguage :: DefaultLanguage -> RawLanguage -> Language
 fromRawLanguage d r =
     Language
         { _name = r ^. #name
+        , _runtime = fromMaybe (d ^. #runtime) (r ^. #runtime)
         , _memory = fromMaybe (d ^. #memory) (r ^. #memory)
         , _cpus = fromMaybe (d ^. #cpus) (r ^. #cpus)
         , _timeout = fromMaybe (d ^. #timeout) (r ^. #timeout)

--- a/src/Myriad/Docker.hs
+++ b/src/Myriad/Docker.hs
@@ -95,7 +95,9 @@ setupContainer lang = do
             cnt <- newContainerName lang
             logInfo ["Setting up new container ", cs cnt]
             exec_
-                [ "docker run --rm --name="
+                [ "docker run --runtime="
+                , cs $ lang ^. #runtime
+                , " --rm --name="
                 , cs cnt
                 -- User 1000 will be for setting up the environment
                 , " -u1000:1000 -w/tmp/ -dt --net=none --cpus="


### PR DESCRIPTION
Since Docker containers with the default runc runtime actually aren't properly sandboxed and not that well suited to run untrusted or even malicious code it's a good security measure to run those containers with a runtime like [Google's gvisor kernel](https://github.com/google/gvisor). This simple change let's you define a custom runtime for every image / language if necessary. This is also my first time that I commit anything in Haskell, so improvements are well appreciated.