### PR TITLE
Add Dockerfile and docker-compose example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM alpine:latest as build
+
+ENV LANG     en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL   en_US.UTF-8
+
+WORKDIR /tmp/haskell
+RUN apk update && \
+    apk upgrade --available && \
+    apk add \
+        build-base make cmake gcc gmp curl xz perl cpio coreutils \
+        binutils-gold tar gzip unzip \
+        libc-dev musl-dev ncurses-dev gmp-dev zlib-dev expat-dev libffi-dev \
+        gd-dev postgresql-dev linux-headers
+
+RUN curl https://gitlab.haskell.org/haskell/ghcup-hs/raw/master/bootstrap-haskell -sSf | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh && \
+    /root/.ghcup/bin/ghcup set
+ENV PATH "$PATH:/root/.cabal/bin:/root/.ghcup/bin"
+
+WORKDIR /tmp/myriad
+COPY . .
+RUN cabal new-install
+
+RUN mkdir -p /opt/myriad && \
+    cp -L /root/.cabal/bin/myriad /opt/myriad && \
+    mv languages /opt/myriad && \
+    mv config.example.yaml /opt/myriad/config.yaml
+
+
+FROM alpine:latest
+RUN apk add --no-cache docker-cli gmp
+WORKDIR /opt/myriad
+COPY --from=build /opt/myriad .
+
+EXPOSE 8081
+
+CMD ["./myriad"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,19 @@
+FROM frolvlad/alpine-glibc:latest as build
+
+ARG MYRIAD_VERSION=0.5.0.3
+ARG GHC_VERSION=8.8.3
+
+RUN apk add --no-cache curl tar gzip
+WORKDIR /tmp/myriad
+RUN curl -OL https://github.com/1Computer1/myriad/releases/download/${MYRIAD_VERSION}/myriad-${MYRIAD_VERSION}-Linux-${GHC_VERSION}.tar.gz && \
+    tar -xzf myriad-${MYRIAD_VERSION}-Linux-${GHC_VERSION}.tar.gz && \
+    rm -f myriad-${MYRIAD_VERSION}-Linux-${GHC_VERSION}.tar.gz
+
+FROM frolvlad/alpine-glibc:latest
+RUN apk add --no-cache docker-cli gmp
+WORKDIR /opt/myriad
+COPY --from=build /tmp/myriad .
+
+EXPOSE 8081
+
+CMD ["./myriad"]

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  myriad:
+    build:
+      context: .
+      dockerfile: Dockerfile.release
+    image: myriad:latest
+    container_name: myriad
+    network_mode: bridge
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./config.yaml:/opt/myriad/config.yaml:ro
+    ports:
+      - 127.0.0.1:8081:8081/tcp
+      - ::1:8081:8081/tcp
+    restart: unless-stopped


### PR DESCRIPTION
Since I prefer to run services that access the Docker daemon containerized in Docker itself, I made a Dockerfile that compiles myriad on alpine-musl and packages it with the docker-cli. Alternatively there is a simple Dockerfile that uses the precompiled binaries from the repo and packages it with a glibc variant. Alpine is used instead of a base image like Debian because it of course offers very small image sizes despite the small headache of compiling against musl but it also is the only linux distro that offers just the docker-cli in a single package that makes it quite well suited for this application. With a debian base image one would have to pull the entire docker package including the server daemon to get the cli binary and there apparently isn't just a way to pull just the binary pre-compiled from somewhere official.
In addition I included an example docker-compose.yml that I use in a similar fashion.