### PR TITLE
Update images and reduce their size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ COPY --from=build /opt/myriad .
 
 EXPOSE 8081
 
-CMD ["./myriad"]
+ENTRYPOINT ["./myriad"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -16,4 +16,4 @@ COPY --from=build /tmp/myriad .
 
 EXPOSE 8081
 
-CMD ["./myriad"]
+ENTRYPOINT ["./myriad"]

--- a/languages/brainfuck/Dockerfile
+++ b/languages/brainfuck/Dockerfile
@@ -1,12 +1,12 @@
-FROM alpine AS build
+FROM alpine as build
 
-RUN apk update && apk add g++
 COPY bf.cpp .
-RUN g++ bf.cpp -o bf
+RUN apk add --no-cache g++ && \
+    g++ bf.cpp -o bf
 
 FROM alpine
 LABEL author="1Computer1"
 
-RUN apk update && apk add libstdc++
+RUN apk add --no-cache libstdc++
 COPY --from=build bf /usr/local/bin/
 COPY run.sh /var/run/

--- a/languages/brainfuck/Dockerfile
+++ b/languages/brainfuck/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine as build
+FROM alpine AS build
 
 COPY bf.cpp .
 RUN apk add --no-cache g++ && \

--- a/languages/c/Dockerfile
+++ b/languages/c/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine
 LABEL author="1Computer1"
 
-RUN apk update
-RUN apk add gcc libc-dev
+RUN apk add --no-cache gcc libc-dev
 
 COPY run.sh /var/run/

--- a/languages/cpp/Dockerfile
+++ b/languages/cpp/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine
 LABEL author="1Computer1"
 
-RUN apk update
-RUN apk add g++
+RUN apk add --no-cache g++
 
 COPY run.sh /var/run/

--- a/languages/haskell/Dockerfile
+++ b/languages/haskell/Dockerfile
@@ -1,14 +1,17 @@
-FROM debian:stretch
+FROM debian:stable-slim
 LABEL author="1Computer1"
 ENV LANG C.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gnupg dirmngr && \
-    echo 'deb http://downloads.haskell.org/debian stretch main' > /etc/apt/sources.list.d/ghc.list && \
+    apt-get install -y --no-install-recommends gnupg dirmngr ca-certificates && \
+    echo 'deb https://downloads.haskell.org/debian stretch main' > /etc/apt/sources.list.d/ghc.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA3CBA3FFE22B574 && \
     apt-get update && \
-    apt-get install -y --no-install-recommends ghc-8.6.5
+    apt-get install -y --no-install-recommends ghc-9.0.1 && \
+    apt-get purge -y gnupg dirmngr ca-certificates && \
+    apt-get autoremove -y && \
+    apt-get autoclean -y
 
-ENV PATH /opt/ghc/8.6.5/bin:$PATH
+ENV PATH /opt/ghc/9.0.1/bin:$PATH
 
 COPY run.sh /var/run/

--- a/languages/idris/Dockerfile
+++ b/languages/idris/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:latest
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk update && \
-    apk add idris@testing
+    apk add idris@testing && \
+    rm -rf /var/cache/apk/*
 
 COPY run.sh /var/run/

--- a/languages/java/Dockerfile
+++ b/languages/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:13-alpine
+FROM openjdk:17-alpine
 LABEL author="1Computer1"
 
 COPY run.sh /var/run/

--- a/languages/javascript/run.sh
+++ b/languages/javascript/run.sh
@@ -1,2 +1,1 @@
-cat > program.js
-node program.js
+cat | node

--- a/languages/javascript/run.sh
+++ b/languages/javascript/run.sh
@@ -1,1 +1,2 @@
-cat | node -p
+cat > program.js
+node program.js

--- a/languages/lua/Dockerfile
+++ b/languages/lua/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine
 
-RUN apk update
-RUN apk add lua5.3
+RUN apk add --no-cache lua5.3
 
 COPY run.sh /var/run/

--- a/languages/typescript/Dockerfile
+++ b/languages/typescript/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 LABEL author="1Computer1"
 
-RUN npm install --global --save-dev @swc/core @swc/register
+RUN yarn global add typescript @types/node
 
 COPY run.sh /var/run/

--- a/languages/typescript/Dockerfile
+++ b/languages/typescript/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 LABEL author="1Computer1"
 
-RUN yarn global add typescript @types/node
+RUN npm install --global --save-dev @swc/core @swc/register
 
 COPY run.sh /var/run/

--- a/languages/typescript/run.sh
+++ b/languages/typescript/run.sh
@@ -1,4 +1,2 @@
 cat > program.ts
-tsc --lib DOM,ESNext --target ES2019 --strict \
-    --skipLibCheck --types /usr/local/share/.config/yarn/global/node_modules/@types/node program.ts \
-    && cat program.js | node -p 
+swc-node program.ts

--- a/languages/typescript/run.sh
+++ b/languages/typescript/run.sh
@@ -1,2 +1,4 @@
 cat > program.ts
-swc-node program.ts
+tsc --lib DOM,ESNext --target ES2019 --strict \
+    --skipLibCheck --types /usr/local/share/.config/yarn/global/node_modules/@types/node program.ts \
+    && cat program.js | node


### PR DESCRIPTION
* Update java and haskell image to latest version
* Change from CMD to ENTRYPOINT in Dockerfile to allow custom command/arguments to be set on start
* Reduce several image sizes by deleting not needed cache files (in case of alpine it's unnecessary to `apk update` first unless a new repo has been added)

Changes I would like to have feedback on as I am not sure whether it fully replaces the current solution:
* Replace tsc transpiler with [swc](https://github.com/swc-project/register) to dramatically reduce evaluation time for typescript code. (With half of a current-gen xeon core the current typescript image regularly times out even with simple programs)
* Don't print result of typescript and javascript code by default to also be consistent with the other language images that explicitly require the user to print to console